### PR TITLE
lock mosdef versions to ff-utils=0.3.0, foyer =0.12.1 gmso =0.12.1, mbuild =0.17.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,10 @@ requirements:
     - sympy
     - symengine
     - python-symengine
-    - forcefield-utilities >=0.2.2
-    - foyer >=0.12.0
-    - gmso >=0.11.2
-    - mbuild >=0.16.4
+    - forcefield-utilities =0.3.0
+    - foyer =0.12.1
+    - gmso =0.12.1
+    - mbuild =0.17.1
 
 test:
   imports:


### PR DESCRIPTION
Because of the gmso =0.12.2 bug:

lock mosdef versions to ff-utils=0.3.0, foyer =0.12.1 gmso =0.12.1, mbuild =0.17.1

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
