### PR TITLE
lock to gmso version 0.14.0 as version 0.15.0 does not allow the creation of empty boxes in dual box systems.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set python_max = '3.14' %}
 {% set name = "mosdef-gomc" %}
 {% set version = "1.5.0" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: {{ name|lower }}
@@ -33,7 +33,7 @@ requirements:
     - numpy >=2.0,<2.3
     - forcefield-utilities >=0.4.0
     - foyer >=1.0.1
-    - gmso >=0.14.0
+    - gmso =0.14.0
     - mbuild >=1.2.1
     - pytest
     - pytest-cov


### PR DESCRIPTION
lock to gmso version 0.14.0 as version 0.15.0 does not allow the creation of empty boxes in dual box systems.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
